### PR TITLE
Safely Handle Cancel if non-initialized toast

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ toast.show();
 
 ##Config
 
-`Toasty(message:string,duration?:string,position?:string);`
+`Toasty(message:string, duration?:string, position?:string);`
 
 ```
 duration = "short | long";
 position = "bottom | center | top";
-``` 
+```

--- a/toasty.android.ts
+++ b/toasty.android.ts
@@ -59,6 +59,8 @@ export class Toasty {
         }
     }
     cancel() {
-        this._toast.cancel();
+        if(this._toast) {
+            this._toast.cancel();
+        }
     }
 }

--- a/toasty.ios.ts
+++ b/toasty.ios.ts
@@ -56,6 +56,8 @@ export class Toasty {
         }
     }
     cancel() {
-        this._toast.self.cs_hideToast(this._toast);
+        if(this._toast) {
+            this._toast.self.cs_hideToast(this._toast);
+        }
     }
 }


### PR DESCRIPTION
Prevent crashing the application, if the user calls `cancel()` on a non-initialized instance of Toast. 