### PR TITLE
Fix 'cancel' and toast positioning in modals on iPad

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ demo/platforms
 demo/node_modules
 node_modules
 .vscode
-.ideas
+.idea
 
 .DS_Store
 

--- a/demo/app/main-page.ts
+++ b/demo/app/main-page.ts
@@ -24,3 +24,11 @@ export function positionToast() {
   toast.duration = ToastDuration.SHORT;
   toast.show();
 }
+
+export function cancelToast() {
+  const toast = new Toasty('Canceling after 1 sec');
+  toast.show();
+  setTimeout(() => {
+    toast.cancel();
+  }, 1000);
+}

--- a/demo/app/main-page.xml
+++ b/demo/app/main-page.xml
@@ -12,6 +12,9 @@
 
       <Label text="You can chain the toast methods for setting position and duration." class="h3 m-5" textWrap="true" />
       <Button text="Chained Toast" tap="chainedToast" class="btn btn-pink" />
+
+      <Label text="You can cancel a Toast (hide it)." class="h3 m-5" textWrap="true" />
+      <Button text="Cancel Toast" tap="cancelToast" class="btn btn-pink" />
     </StackLayout>
   </ScrollView>
 </Page>

--- a/src/toasty.ios.ts
+++ b/src/toasty.ios.ts
@@ -1,6 +1,7 @@
 /// <reference path="./typings/objc!Toast.d.ts" />
 
-import * as app from 'tns-core-modules/application';
+import { device } from 'tns-core-modules/platform';
+import { DeviceType } from 'tns-core-modules/ui/enums';
 import * as frameModule from 'tns-core-modules/ui/frame';
 import { ToastDuration, ToastPosition } from './toast.common';
 export * from './toast.common';
@@ -49,24 +50,12 @@ export class Toasty {
     if (!this._text) {
       throw new Error('Text is not set');
     } else {
-      if (!frameModule.topmost()) {
-        throw new Error('There is no topmost');
-      } else {
-        let viewController = frameModule.topmost().viewController;
-        let view = viewController.view;
-        if (viewController.presentedViewController) {
-          while (viewController.presentedViewController) {
-            viewController = viewController.presentedViewController;
-          }
-          view = viewController.view;
-        }
-        view.makeToast(this._text);
-      }
+      Toasty.getView().makeToast(this._text);
     }
   }
 
   cancel() {
-    app.ios.rootController.view.hideToasts();
+    Toasty.getView().hideToasts();
   }
 
   setToastPosition(value: ToastPosition) {
@@ -102,5 +91,22 @@ export class Toasty {
     }
 
     return this;
+  }
+
+  private static getView(): any {
+    if (!frameModule.topmost()) {
+      throw new Error('There is no topmost');
+    } else {
+      let viewController = frameModule.topmost().viewController;
+      if (viewController.presentedViewController) {
+        // on iPad, we don't want to show the toast in the modal, but on iPhone we do
+        if (device.deviceType !== DeviceType.Tablet) {
+          while (viewController.presentedViewController) {
+            viewController = viewController.presentedViewController;
+          }
+        }
+      }
+      return viewController.view;
+    }
   }
 }


### PR DESCRIPTION
Hey Osei!

Thanks for maintaining this beauty 😊

I ran into two little issues on iOS, hope you can merge and bump it soon.

- Fixes the 'cancel' feature: it wasn't working for all implementations of the {N} view hierarchy (and modals). I've added it to the demo as well.

- Also fixes toasts on iPad modals; they should be positioned at the bottom of the screen, not at the bottom of the modal. Compare the screenshots below for reference.

_**without** this PR applied:_
![Simulator Screen Shot - iPad Pro (9 7-inch) - 2019-05-18 at 15 49 56](https://user-images.githubusercontent.com/1426370/57970918-a8bcc480-7987-11e9-9efd-883ceb42ff83.png)

_**with** this PR applied:_
![Simulator Screen Shot - iPad Pro (9 7-inch) - 2019-05-18 at 15 59 48](https://user-images.githubusercontent.com/1426370/57970919-a8bcc480-7987-11e9-85b4-6a516b478d86.png)
