### PR TITLE
Fixed null iOS options

### DIFF
--- a/src/toasty.ios.ts
+++ b/src/toasty.ios.ts
@@ -23,7 +23,7 @@ export class Toasty {
     this._position = opts.position;
     this._textColor = opts.textColor;
     this._backgroundColor = opts.backgroundColor;
-    this._iOSOpts = opts.ios;
+    this._iOSOpts = opts.ios || {};
 
     // set the defaults for the toasty, if passed in constructor those values are used
     this.setToastDuration(this._duration)


### PR DESCRIPTION
This PR solves the following error on iOS:

> CONSOLE ERROR [native code]: ERROR TypeError: undefined is not an object (evaluating 'this._iOSOpts.displayShadow')

Which occurs due to a null/undefined reference to `opts.ios` when the toast is created without ios options. Example for failure in the code below:

```
const toast = new Toasty({ text: 'Toast message' });
toast.show();
```
Or

```
new Toasty({ text: 'Some Message' })
  .setToastDuration(ToastDuration.LONG)
  .setToastPosition(ToastPosition.BOTTOM)
  .setTextColor(new Color('white'))
  .setBackgroundColor('#ff9999')
  .show();
```