### PR TITLE
Fixes #29, show ios top toasts in safe area

### DIFF
--- a/src/platforms/ios/Podfile
+++ b/src/platforms/ios/Podfile
@@ -1,1 +1,1 @@
-pod 'Toast', '~> 3.0'
+pod 'Toast', '~> 4.0'


### PR DESCRIPTION
Latest pod [scalessec/Toast](https://github.com/scalessec/Toast) v4.0 fixes issue, when top positioned toast is shown under notch.

I haven't checked whether everything runs correctly, or there is any other changes needed after updating ios library, but in my simple use case:
```
new Toasty({text: 'Удалено из избранных', position: ToastPosition.TOP}).show();
```
this update fixes safe area behavior and everything works.