### PR TITLE
Allow corner radius to be 0

### DIFF
--- a/src/toasty.ios.ts
+++ b/src/toasty.ios.ts
@@ -58,9 +58,10 @@ export class Toasty {
       }
     }
 
-    if (this._iOSOpts.cornerRadius) {
+    if (this._iOSOpts.cornerRadius || this._iOSOpts.cornerRadius === 0) {
       this._toastStyle.cornerRadius = this._iOSOpts.cornerRadius;
     }
+
     if (this._iOSOpts.messageNumberOfLines) {
       this._toastStyle.messageNumberOfLines = this._iOSOpts.messageNumberOfLines;
     }


### PR DESCRIPTION
Currently you have a check for 

```ts
if (this._iOSOpts.cornerRadius) {
```
But `0` is falsy. The workaround is to pass a negative number but it's not ideal. Please consider this minor fix :). 